### PR TITLE
replace deprecated cricket::VideoCapturer with rtc::AdaptedVideoTrackSource

### DIFF
--- a/plugins/obs-outputs/AudioDeviceModuleWrapper.cpp
+++ b/plugins/obs-outputs/AudioDeviceModuleWrapper.cpp
@@ -1,5 +1,5 @@
 #include "AudioDeviceModuleWrapper.h"
-#include "rtc_base/timeutils.h"
+#include "rtc_base/time_utils.h"
 #include "obs.h"
 #include "media-io/audio-io.h"
 

--- a/plugins/obs-outputs/AudioDeviceModuleWrapper.h
+++ b/plugins/obs-outputs/AudioDeviceModuleWrapper.h
@@ -4,8 +4,8 @@
 #include <stdio.h>
 
 #include "modules/audio_device/audio_device_generic.h"
-#include "rtc_base/refcountedobject.h"
-#include "rtc_base/criticalsection.h"
+#include "rtc_base/ref_counted_object.h"
+#include "rtc_base/critical_section.h"
 #include "rtc_base/checks.h"
 
 using webrtc::AudioDeviceBuffer;
@@ -34,7 +34,7 @@ public:
   }
 
   // Error handling
-  virtual ErrorCode LastError() const { return (ErrorCode)0;  }
+  // virtual ErrorCode LastError() const { return (ErrorCode)0; } // ErrorCode deprecated in webrtc 75
 
   // Full-duplex transportation of PCM audio
   virtual int32_t RegisterAudioCallback(AudioTransport* audioTransport)
@@ -148,8 +148,8 @@ public:
   virtual int32_t StereoRecordingIsAvailable( bool* ) const { return 0; }
   virtual int32_t SetStereoRecording(         bool  )       { return 0; }
   virtual int32_t StereoRecording(            bool* ) const { return 0; }
-  virtual int32_t SetRecordingChannel(        const ChannelType  )       { return 0; }
-  virtual int32_t RecordingChannel(                 ChannelType* ) const { return 0; }
+  // virtual int32_t SetRecordingChannel(        const ChannelType  )       { return 0; } // ChannelType removed in webrtc 75
+  // virtual int32_t RecordingChannel(                 ChannelType* ) const { return 0; } // ChannelType removed in webrtc 75
 
   // Delay information and control
   virtual int32_t PlayoutDelay(   uint16_t* ) const { return 0; }

--- a/plugins/obs-outputs/VideoCapturer.h
+++ b/plugins/obs-outputs/VideoCapturer.h
@@ -1,32 +1,39 @@
 #ifndef _OBS_VIDEO_CAPTURER_
 #define _OBS_VIDEO_CAPTURER_
 
-
-#include "media/base/video_capturer.h"
+#include "media/base/adapted_video_track_source.h"
 #include "rtc_base/thread.h"
 
 #include <mutex>
 
 class WebRTCStream;
 
-class VideoCapturer : public cricket::VideoCapturer
+class VideoCapturer : public rtc::AdaptedVideoTrackSource
 {
 public:
     VideoCapturer();
     ~VideoCapturer();
     void OnFrame(const webrtc::VideoFrame& frame);
 
-    // video capturer interface
-    cricket::CaptureState Start(const cricket::VideoFormat& capture_format) override;
-    void Stop() override;
-    bool IsRunning() override { return start_thread_; }
-    bool IsScreencast() const override { return false; }
-    bool GetPreferredFourccs(std::vector<uint32_t>* /* unused fourccs */) override { return true; }
+    webrtc::MediaSourceInterface::SourceState Start();
+    void Stop();
+    bool IsRunning() { return start_thread_; }
+    bool IsScreencast() const { return false; }
+    bool GetPreferredFourccs(std::vector<uint32_t> * /* unused fourccs */) { return true; }
+
+    // VideoTrackSourceInterface API
+    bool is_screencast() const override { return false; }
+    absl::optional<bool> needs_denoising() const override { return false; }
+
+    // MediaSourceInterface API
+    webrtc::MediaSourceInterface::SourceState state() const override;
+    bool remote() const override { return false; }
 
 private:
     rtc::Thread* start_thread_;
     int captured_frames_;
-    std::mutex  mutex;
+    std::mutex mutex;
+    webrtc::MediaSourceInterface::SourceState state_;
 };
 
 #endif

--- a/plugins/obs-outputs/WebRTCStream.h
+++ b/plugins/obs-outputs/WebRTCStream.h
@@ -22,11 +22,11 @@
 
 #include "api/media_stream_interface.h"
 #include "api/peer_connection_interface.h"
-#include "api/media_constraints_interface.h"
 #include "api/create_peerconnection_factory.h"
-#include "rtc_base/scoped_ref_ptr.h"
+#include "api/scoped_refptr.h"
 #include "rtc_base/ref_counted_object.h"
 #include "rtc_base/thread.h"
+#include "rtc_base/timestamp_aligner.h"
 
 class WebRTCStreamInterface :
   public WebsocketClient::Listener,
@@ -117,6 +117,7 @@ private:
   //bitrate and dropped frames
   uint64_t bitrate;
   int dropped_frame;
+  uint16_t id;
 
   //Websocket client
   WebsocketClient* client;
@@ -125,7 +126,8 @@ private:
   AudioDeviceModuleWrapper adm;
 
   //Video Capturer
-  VideoCapturer* videoCapturer;
+  rtc::scoped_refptr<VideoCapturer> videoCapturer;
+  rtc::TimestampAligner timestamp_aligner_;
 
   //Thumbnail wrapper
   //webrtc::VideoCaptureCapability thumbnailCaptureCapability;

--- a/plugins/obs-outputs/evercast-stream.cpp
+++ b/plugins/obs-outputs/evercast-stream.cpp
@@ -6,7 +6,7 @@
 #include <util/threading.h>
 #include <inttypes.h>
 #include <rtc_base/platform_file.h>
-#include <rtc_base/bitrateallocationstrategy.h>
+#include <rtc_base/bitrate_allocation_strategy.h>
 #include <modules/audio_processing/include/audio_processing.h>
 
 #define warn(format, ...)  blog(LOG_WARNING, format, ##__VA_ARGS__)

--- a/plugins/obs-outputs/janus-stream.cpp
+++ b/plugins/obs-outputs/janus-stream.cpp
@@ -6,7 +6,7 @@
 #include <util/threading.h>
 #include <inttypes.h>
 #include <rtc_base/platform_file.h>
-#include <rtc_base/bitrateallocationstrategy.h>
+#include <rtc_base/bitrate_allocation_strategy.h>
 #include <modules/audio_processing/include/audio_processing.h>
 
 #define warn(format, ...)  blog(LOG_WARNING, format, ##__VA_ARGS__)

--- a/plugins/obs-outputs/millicast-stream.cpp
+++ b/plugins/obs-outputs/millicast-stream.cpp
@@ -6,7 +6,7 @@
 #include <util/threading.h>
 #include <inttypes.h>
 #include <rtc_base/platform_file.h>
-#include <rtc_base/bitrateallocationstrategy.h>
+#include <rtc_base/bitrate_allocation_strategy.h>
 #include <modules/audio_processing/include/audio_processing.h>
 
 #define warn(format, ...)  blog(LOG_WARNING, format, ##__VA_ARGS__)


### PR DESCRIPTION
Successfully broadcasts using WebRTC 75 configured with:

`gn gen out/Release --args='use_rtti=true is_debug=false libcxx_abi_unstable=false rtc_use_h264=true use_openh264=true proprietary_codecs=true ffmpeg_branding="Chrome" rtc_include_tests=false rtc_build_examples=false rtc_build_tools=false'`