### PR TITLE
obs-outputs: update librtmp from obs-studio trunk (23.2)

### DIFF
--- a/cmake/Modules/FindMbedTLS.cmake
+++ b/cmake/Modules/FindMbedTLS.cmake
@@ -1,0 +1,143 @@
+# Once done these will be defined:
+#
+#  LIBMBEDTLS_FOUND
+#  LIBMBEDTLS_INCLUDE_DIRS
+#  LIBMBEDTLS_LIBRARIES
+#
+# For use in OBS:
+#
+#  MBEDTLS_INCLUDE_DIR
+
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+	pkg_check_modules(_MBEDTLS QUIET mbedtls)
+endif()
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set(_lib_suffix 64)
+else()
+	set(_lib_suffix 32)
+endif()
+
+# If we're on MacOS or Linux, please try to statically-link mbedtls.
+if(STATIC_MBEDTLS AND (APPLE OR UNIX))
+	set(_MBEDTLS_LIBRARIES libmbedtls.a)
+	set(_MBEDCRYPTO_LIBRARIES libmbedcrypto.a)
+	set(_MBEDX509_LIBRARIES libmbedx509.a)
+endif()
+
+find_path(MBEDTLS_INCLUDE_DIR
+	NAMES mbedtls/ssl.h
+	HINTS
+		ENV mbedtlsPath${_lib_suffix}
+		ENV mbedtlsPath
+		ENV DepsPath${_lib_suffix}
+		ENV DepsPath
+		${mbedtlsPath${_lib_suffix}}
+		${mbedtlsPath}
+		${DepsPath${_lib_suffix}}
+		${DepsPath}
+		${_MBEDTLS_INCLUDE_DIRS}
+	PATHS
+		/usr/include /usr/local/include /opt/local/include /sw/include
+	PATH_SUFFIXES
+		include)
+
+find_library(MBEDTLS_LIB
+	NAMES ${_MBEDTLS_LIBRARIES} mbedtls libmbedtls
+	HINTS
+		ENV mbedtlsPath${_lib_suffix}
+		ENV mbedtlsPath
+		ENV DepsPath${_lib_suffix}
+		ENV DepsPath
+		${mbedtlsPath${_lib_suffix}}
+		${mbedtlsPath}
+		${DepsPath${_lib_suffix}}
+		${DepsPath}
+		${_MBEDTLS_LIBRARY_DIRS}
+	PATHS
+		/usr/lib /usr/local/lib /opt/local/lib /sw/lib
+	PATH_SUFFIXES
+		lib${_lib_suffix} lib
+		libs${_lib_suffix} libs
+		bin${_lib_suffix} bin
+		../lib${_lib_suffix} ../lib
+		../libs${_lib_suffix} ../libs
+		../bin${_lib_suffix} ../bin)
+
+find_library(MBEDCRYPTO_LIB
+	NAMES ${_MBEDCRYPTO_LIBRARIES} mbedcrypto libmbedcrypto
+	HINTS
+		ENV mbedcryptoPath${_lib_suffix}
+		ENV mbedcryptoPath
+		ENV DepsPath${_lib_suffix}
+		ENV DepsPath
+		${mbedcryptoPath${_lib_suffix}}
+		${mbedcryptoPath}
+		${DepsPath${_lib_suffix}}
+		${DepsPath}
+		${_MBEDCRYPTO_LIBRARY_DIRS}
+	PATHS
+		/usr/lib /usr/local/lib /opt/local/lib /sw/lib
+	PATH_SUFFIXES
+		lib${_lib_suffix} lib
+		libs${_lib_suffix} libs
+		bin${_lib_suffix} bin
+		../lib${_lib_suffix} ../lib
+		../libs${_lib_suffix} ../libs
+		../bin${_lib_suffix} ../bin)
+
+find_library(MBEDX509_LIB
+	NAMES ${_MBEDX509_LIBRARIES} mbedx509 libmbedx509
+	HINTS
+		ENV mbedx509Path${_lib_suffix}
+		ENV mbedx509Path
+		ENV DepsPath${_lib_suffix}
+		ENV DepsPath
+		${mbedx509Path${_lib_suffix}}
+		${mbedx509Path}
+		${DepsPath${_lib_suffix}}
+		${DepsPath}
+		${_MBEDX509_LIBRARY_DIRS}
+	PATHS
+		/usr/lib /usr/local/lib /opt/local/lib /sw/lib
+	PATH_SUFFIXES
+		lib${_lib_suffix} lib
+		libs${_lib_suffix} libs
+		bin${_lib_suffix} bin
+		../lib${_lib_suffix} ../lib
+		../libs${_lib_suffix} ../libs
+		../bin${_lib_suffix} ../bin)
+
+# Sometimes mbedtls is split between three libs, and sometimes it isn't.
+# If it isn't, let's check if the symbols we need are all in MBEDTLS_LIB.
+if(MBEDTLS_LIB AND NOT MBEDCRYPTO_LIB AND NOT MBEDX509_LIB)
+	set(CMAKE_REQUIRED_LIBRARIES ${MBEDTLS_LIB})
+	set(CMAKE_REQUIRED_INCLUDES ${MBEDTLS_INCLUDE_DIR})
+	check_symbol_exists(mbedtls_x509_crt_init "mbedtls/x509_crt.h" MBEDTLS_INCLUDES_X509)
+	check_symbol_exists(mbedtls_sha256_init "mbedtls/sha256.h" MBEDTLS_INCLUDES_CRYPTO)
+	unset(CMAKE_REQUIRED_INCLUDES)
+	unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
+
+# If we find all three libraries, then go ahead.
+if(MBEDTLS_LIB AND MBEDCRYPTO_LIB AND MBEDX509_LIB)
+	set(LIBMBEDTLS_INCLUDE_DIRS ${MBEDTLS_INCLUDE_DIR})
+	set(LIBMBEDTLS_LIBRARIES ${MBEDTLS_LIB} ${MBEDCRYPTO_LIB} ${MBEDX509_LIB})
+	set(MBEDTLS_INCLUDE_DIRS ${LIBMBEDTLS_INCLUDE_DIRS})
+	set(MBEDTLS_LIBRARIES ${LIBMBEDTLS_LIBRARIES})
+
+# Otherwise, if we find MBEDTLS_LIB, and it has both CRYPTO and x509
+# within the single lib (i.e. a windows build environment), then also
+# feel free to go ahead.
+elseif(MBEDTLS_LIB AND MBEDTLS_INCLUDES_CRYPTO AND MBEDTLS_INCLUDES_X509)
+	set(LIBMBEDTLS_INCLUDE_DIRS ${MBEDTLS_INCLUDE_DIR})
+	set(LIBMBEDTLS_LIBRARIES ${MBEDTLS_LIB})
+	set(MBEDTLS_INCLUDE_DIRS ${LIBMBEDTLS_INCLUDE_DIRS})
+	set(MBEDTLS_LIBRARIES ${LIBMBEDTLS_LIBRARIES})
+endif()
+
+# Now we've accounted for the 3-vs-1 library case:
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libmbedtls DEFAULT_MSG MBEDTLS_LIBRARIES MBEDTLS_INCLUDE_DIRS)
+mark_as_advanced(MBEDTLS_INCLUDE_DIR MBEDTLS_LIBRARIES MBEDTLS_INCLUDE_DIRS)

--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -175,7 +175,7 @@ target_include_directories( obs-outputs
   )
 target_link_libraries( obs-outputs
   ${WEBRTC_LIBRARIES}
-  ${SSL_LIBRARIES}
+  ${LIBMBEDTLS_LIBRARIES}
   ${ZLIB_LIBRARIES}
   ${obs-outputs_PLATFORM_DEPS}
   libobs

--- a/plugins/obs-outputs/librtmp/cencode.c
+++ b/plugins/obs-outputs/librtmp/cencode.c
@@ -48,6 +48,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			result = (fragment & 0x0fc) >> 2;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x003) << 4;
+			/* Falls through. */
 	case step_B:
 			if (plainchar == plaintextend)
 			{
@@ -59,6 +60,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			result |= (fragment & 0x0f0) >> 4;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x00f) << 2;
+			/* Falls through. */
 	case step_C:
 			if (plainchar == plaintextend)
 			{

--- a/plugins/obs-outputs/librtmp/dh.h
+++ b/plugins/obs-outputs/librtmp/dh.h
@@ -21,7 +21,59 @@
  *  http://www.gnu.org/copyleft/lgpl.html
  */
 
-#ifdef USE_POLARSSL
+#if defined(USE_MBEDTLS)
+#include <mbedtls/dhm.h>
+#include <mbedtls/bignum.h>
+typedef  mbedtls_mpi* MP_t;
+#define MP_new(m)	m = malloc(sizeof(mbedtls_mpi)); mbedtls_mpi_init(m)
+#define MP_set_w(mpi, w)	mbedtls_mpi_lset(mpi, w)
+#define MP_cmp(u, v)	mbedtls_mpi_cmp_mpi(u, v)
+#define MP_set(u, v)	mbedtls_mpi_copy(u, v)
+#define MP_sub_w(mpi, w)	mbedtls_mpi_sub_int(mpi, mpi, w)
+#define MP_cmp_1(mpi)	mbedtls_mpi_cmp_int(mpi, 1)
+#define MP_modexp(r, y, q, p)	mbedtls_mpi_exp_mod(r, y, q, p, NULL)
+#define MP_free(mpi)	mbedtls_mpi_free(mpi); free(mpi)
+#define MP_gethex(u, hex, res)	MP_new(u); res = mbedtls_mpi_read_string(u, 16, hex) == 0
+#define MP_bytes(u)	mbedtls_mpi_size(u)
+#define MP_setbin(u,buf,len)	mbedtls_mpi_write_binary(u,buf,len)
+#define MP_getbin(u,buf,len)	MP_new(u); mbedtls_mpi_read_binary(u,buf,len)
+
+typedef struct MDH
+{
+    MP_t p;
+    MP_t g;
+    MP_t pub_key;
+    MP_t priv_key;
+    long length;
+    mbedtls_dhm_context ctx;
+} MDH;
+
+#define MDH_new()	calloc(1,sizeof(MDH))
+#define MDH_free(vp)	{MDH *_dh = vp; mbedtls_dhm_free(&_dh->ctx); MP_free(_dh->p); MP_free(_dh->g); MP_free(_dh->pub_key); MP_free(_dh->priv_key); free(_dh);}
+
+static int MDH_generate_key(MDH *dh)
+{
+    unsigned char out[2];
+    MP_set(&dh->ctx.P, dh->p);
+    MP_set(&dh->ctx.G, dh->g);
+    dh->ctx.len = 128;
+    mbedtls_dhm_make_public(&dh->ctx, 1024, out, 1, mbedtls_ctr_drbg_random, &RTMP_TLS_ctx->ctr_drbg);
+    MP_new(dh->pub_key);
+    MP_new(dh->priv_key);
+    MP_set(dh->pub_key, &dh->ctx.GX);
+    MP_set(dh->priv_key, &dh->ctx.X);
+    return 1;
+}
+
+static int MDH_compute_key(uint8_t *secret, size_t len, MP_t pub, MDH *dh)
+{
+    MP_set(&dh->ctx.GY, pub);
+    size_t olen;
+    mbedtls_dhm_calc_secret(&dh->ctx, secret, len, &olen, NULL, NULL);
+    return 0;
+}
+
+#elif defined(USE_POLARSSL)
 #include <polarssl/dhm.h>
 typedef mpi * MP_t;
 #define MP_new(m)	m = malloc(sizeof(mpi)); mpi_init(m)
@@ -271,7 +323,7 @@ DHGetPublicKey(MDH *dh, uint8_t *pubkey, size_t nPubkeyLen)
     if (!dh || !dh->pub_key)
         return 0;
 
-    len = MP_bytes(dh->pub_key);
+    len = (int)MP_bytes(dh->pub_key);
     if (len <= 0 || len > (int) nPubkeyLen)
         return 0;
 

--- a/plugins/obs-outputs/librtmp/handshake.h
+++ b/plugins/obs-outputs/librtmp/handshake.h
@@ -24,7 +24,28 @@
 
 /* This file is #included in rtmp.c, it is not meant to be compiled alone */
 
-#ifdef USE_POLARSSL
+#if defined(USE_MBEDTLS)
+#include <mbedtls/md.h>
+#include <mbedtls/arc4.h>
+#ifndef SHA256_DIGEST_LENGTH
+#define SHA256_DIGEST_LENGTH	32
+#endif
+typedef mbedtls_md_context_t *HMAC_CTX;
+#define HMAC_setup(ctx, key, len)	ctx = malloc(sizeof(mbedtls_md_context_t)); mbedtls_md_init(ctx); \
+  mbedtls_md_setup(ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1); \
+  mbedtls_md_hmac_starts(ctx, (const unsigned char *)key, len)
+#define HMAC_crunch(ctx, buf, len)	mbedtls_md_hmac_update(ctx, buf, len)
+#define HMAC_finish(ctx, dig)		mbedtls_md_hmac_finish(ctx, dig)
+#define HMAC_close(ctx)			mbedtls_md_free(ctx); free(ctx); ctx = NULL
+
+typedef mbedtls_arc4_context*	RC4_handle;
+#define RC4_alloc(h)	*h = malloc(sizeof(mbedtls_arc4_context)); mbedtls_arc4_init(*h)
+#define RC4_setkey(h,l,k)	mbedtls_arc4_setup(h,k,l)
+#define RC4_encrypt(h,l,d)	mbedtls_arc4_crypt(h,l,(unsigned char *)d,(unsigned char *)d)
+#define RC4_encrypt2(h,l,s,d)	mbedtls_arc4_crypt(h,l,(unsigned char *)s,(unsigned char *)d)
+#define RC4_free(h)	mbedtls_arc4_free(h); free(h); h = NULL
+
+#elif defined(USE_POLARSSL)
 #include <polarssl/sha2.h>
 #include <polarssl/arc4.h>
 #ifndef SHA256_DIGEST_LENGTH
@@ -33,7 +54,7 @@
 #define HMAC_CTX	sha2_context
 #define HMAC_setup(ctx, key, len)	sha2_hmac_starts(&ctx, (unsigned char *)key, len, 0)
 #define HMAC_crunch(ctx, buf, len)	sha2_hmac_update(&ctx, buf, len)
-#define HMAC_finish(ctx, dig, dlen)	dlen = SHA256_DIGEST_LENGTH; sha2_hmac_finish(&ctx, dig)
+#define HMAC_finish(ctx, dig)		sha2_hmac_finish(&ctx, dig)
 
 typedef arc4_context *	RC4_handle;
 #define RC4_alloc(h)	*h = malloc(sizeof(arc4_context))
@@ -52,7 +73,7 @@ typedef arc4_context *	RC4_handle;
 #define HMAC_CTX	struct hmac_sha256_ctx
 #define HMAC_setup(ctx, key, len)	hmac_sha256_set_key(&ctx, len, key)
 #define HMAC_crunch(ctx, buf, len)	hmac_sha256_update(&ctx, len, buf)
-#define HMAC_finish(ctx, dig, dlen)	dlen = SHA256_DIGEST_LENGTH; hmac_sha256_digest(&ctx, SHA256_DIGEST_LENGTH, dig)
+#define HMAC_finish(ctx, dig)		hmac_sha256_digest(&ctx, SHA256_DIGEST_LENGTH, dig)
 #define HMAC_close(ctx)
 
 typedef struct arcfour_ctx*	RC4_handle;
@@ -71,7 +92,7 @@ typedef struct arcfour_ctx*	RC4_handle;
 #endif
 #define HMAC_setup(ctx, key, len)	HMAC_CTX_init(&ctx); HMAC_Init_ex(&ctx, key, len, EVP_sha256(), 0)
 #define HMAC_crunch(ctx, buf, len)	HMAC_Update(&ctx, buf, len)
-#define HMAC_finish(ctx, dig, dlen)	HMAC_Final(&ctx, dig, &dlen); HMAC_CTX_cleanup(&ctx)
+#define HMAC_finish(ctx, dig, len)	HMAC_Final(&ctx, dig, &len); HMAC_CTX_cleanup(&ctx)
 
 typedef RC4_KEY *	RC4_handle;
 #define RC4_alloc(h)	*h = malloc(sizeof(RC4_KEY))
@@ -118,7 +139,9 @@ static void InitRC4Encryption
  uint8_t * pubKeyOut, RC4_handle *rc4keyIn, RC4_handle *rc4keyOut)
 {
     uint8_t digest[SHA256_DIGEST_LENGTH];
+#if !(defined(USE_MBEDTLS) || defined(USE_POLARSSL) || defined(USE_GNUTLS))
     unsigned int digestLen = 0;
+#endif
     HMAC_CTX ctx;
 
     RC4_alloc(rc4keyIn);
@@ -126,7 +149,11 @@ static void InitRC4Encryption
 
     HMAC_setup(ctx, secretKey, 128);
     HMAC_crunch(ctx, pubKeyIn, 128);
+#if defined(USE_MBEDTLS) || defined(USE_POLARSSL) || defined(USE_GNUTLS)
+    HMAC_finish(ctx, digest);
+#else
     HMAC_finish(ctx, digest, digestLen);
+#endif
 
     RTMP_Log(RTMP_LOGDEBUG, "RC4 Out Key: ");
     RTMP_LogHex(RTMP_LOGDEBUG, digest, 16);
@@ -135,7 +162,11 @@ static void InitRC4Encryption
 
     HMAC_setup(ctx, secretKey, 128);
     HMAC_crunch(ctx, pubKeyOut, 128);
+#if defined(USE_MBEDTLS) || defined(USE_POLARSSL) || defined(USE_GNUTLS)
+    HMAC_finish(ctx, digest);
+#else
     HMAC_finish(ctx, digest, digestLen);
+#endif
 
     RTMP_Log(RTMP_LOGDEBUG, "RC4 In Key: ");
     RTMP_LogHex(RTMP_LOGDEBUG, digest, 16);
@@ -148,6 +179,8 @@ typedef unsigned int (getoff)(uint8_t *buf, unsigned int len);
 static unsigned int
 GetDHOffset2(uint8_t *handshake, unsigned int len)
 {
+    (void) len;
+
     unsigned int offset = 0;
     uint8_t *ptr = handshake + 768;
     unsigned int res;
@@ -177,6 +210,8 @@ GetDHOffset2(uint8_t *handshake, unsigned int len)
 static unsigned int
 GetDigestOffset2(uint8_t *handshake, unsigned int len)
 {
+    (void) len;
+
     unsigned int offset = 0;
     uint8_t *ptr = handshake + 772;
     unsigned int res;
@@ -206,6 +241,8 @@ GetDigestOffset2(uint8_t *handshake, unsigned int len)
 static unsigned int
 GetDHOffset1(uint8_t *handshake, unsigned int len)
 {
+    (void) len;
+
     unsigned int offset = 0;
     uint8_t *ptr = handshake + 1532;
     unsigned int res;
@@ -235,6 +272,8 @@ GetDHOffset1(uint8_t *handshake, unsigned int len)
 static unsigned int
 GetDigestOffset1(uint8_t *handshake, unsigned int len)
 {
+    (void) len;
+
     unsigned int offset = 0;
     uint8_t *ptr = handshake + 8;
     unsigned int res;
@@ -274,7 +313,13 @@ HMACsha256(const uint8_t *message, size_t messageLen, const uint8_t *key,
 
     HMAC_setup(ctx, key, keylen);
     HMAC_crunch(ctx, message, messageLen);
+
+#if defined(USE_MBEDTLS) || defined(USE_POLARSSL) || defined(USE_GNUTLS)
+    digestLen = SHA256_DIGEST_LENGTH;
+    HMAC_finish(ctx, digest);
+#else
     HMAC_finish(ctx, digest, digestLen);
+#endif
 
     assert(digestLen == 32);
 }
@@ -1128,6 +1173,7 @@ HandShake(RTMP * r, int FP9HandShake)
                      __FUNCTION__);
         }
     }
+    // TODO(mgoulet): Should this have a HMAC_finish here?
 
     RTMP_Log(RTMP_LOGDEBUG, "%s: Handshaking finished....", __FUNCTION__);
     return TRUE;
@@ -1481,6 +1527,8 @@ SHandShake(RTMP * r)
                      __FUNCTION__);
         }
     }
+
+    // TODO(mgoulet): Should this have an Rc4_free?
 
     RTMP_Log(RTMP_LOGDEBUG, "%s: Handshaking finished....", __FUNCTION__);
     return TRUE;

--- a/plugins/obs-outputs/librtmp/md5.c
+++ b/plugins/obs-outputs/librtmp/md5.c
@@ -48,18 +48,18 @@
  * architectures that lack an AND-NOT instruction, just like in Colin Plumb's
  * implementation.
  */
-#define F(x, y, z)      ((z) ^ ((x) & ((y) ^ (z))))
-#define G(x, y, z)      ((y) ^ ((z) & ((x) ^ (y))))
-#define H(x, y, z)      ((x) ^ (y) ^ (z))
-#define I(x, y, z)      ((y) ^ ((x) | ~(z)))
+#define F(x, y, z)			((z) ^ ((x) & ((y) ^ (z))))
+#define G(x, y, z)			((y) ^ ((z) & ((x) ^ (y))))
+#define H(x, y, z)			((x) ^ (y) ^ (z))
+#define I(x, y, z)			((y) ^ ((x) | ~(z)))
 
 /*
  * The MD5 transformation for all four rounds.
  */
 #define STEP(f, a, b, c, d, x, t, s) \
-  (a) += f((b), (c), (d)) + (x) + (t); \
-  (a) = (((a) << (s)) | (((a) & 0xffffffff) >> (32 - (s)))); \
-  (a) += (b);
+	(a) += f((b), (c), (d)) + (x) + (t); \
+	(a) = (((a) << (s)) | (((a) & 0xffffffff) >> (32 - (s)))); \
+	(a) += (b);
 
 /*
  * SET reads 4 input bytes in little-endian byte order and stores them
@@ -71,225 +71,226 @@
  */
 #if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
 #define SET(n) \
-  (*(MD5_u32plus *)&ptr[(n) * 4])
+	(*(MD5_u32plus *)&ptr[(n) * 4])
 #define GET(n) \
-  SET(n)
+	SET(n)
 #else
 #define SET(n) \
-  (ctx->block[(n)] = \
-  (MD5_u32plus)ptr[(n) * 4] | \
-  ((MD5_u32plus)ptr[(n) * 4 + 1] << 8) | \
-  ((MD5_u32plus)ptr[(n) * 4 + 2] << 16) | \
-  ((MD5_u32plus)ptr[(n) * 4 + 3] << 24))
+	(ctx->block[(n)] = \
+	(MD5_u32plus)ptr[(n) * 4] | \
+	((MD5_u32plus)ptr[(n) * 4 + 1] << 8) | \
+	((MD5_u32plus)ptr[(n) * 4 + 2] << 16) | \
+	((MD5_u32plus)ptr[(n) * 4 + 3] << 24))
 #define GET(n) \
-  (ctx->block[(n)])
+	(ctx->block[(n)])
 #endif
 
 /*
  * This processes one or more 64-byte data blocks, but does NOT update
  * the bit counters.  There are no alignment requirements.
  */
+// static void *body(MD5_CTX *ctx, void *data, unsigned long size)
 void *body(MD5_CTX *ctx, void *data, unsigned long size)
 {
-  unsigned char *ptr;
-  MD5_u32plus a, b, c, d;
-  MD5_u32plus saved_a, saved_b, saved_c, saved_d;
+	unsigned char *ptr;
+	MD5_u32plus a, b, c, d;
+	MD5_u32plus saved_a, saved_b, saved_c, saved_d;
 
-  ptr = data;
+	ptr = data;
 
-  a = ctx->a;
-  b = ctx->b;
-  c = ctx->c;
-  d = ctx->d;
+	a = ctx->a;
+	b = ctx->b;
+	c = ctx->c;
+	d = ctx->d;
 
-  do {
-    saved_a = a;
-    saved_b = b;
-    saved_c = c;
-    saved_d = d;
+	do {
+		saved_a = a;
+		saved_b = b;
+		saved_c = c;
+		saved_d = d;
 
 /* Round 1 */
-    STEP(F, a, b, c, d, SET(0), 0xd76aa478, 7)
-    STEP(F, d, a, b, c, SET(1), 0xe8c7b756, 12)
-    STEP(F, c, d, a, b, SET(2), 0x242070db, 17)
-    STEP(F, b, c, d, a, SET(3), 0xc1bdceee, 22)
-    STEP(F, a, b, c, d, SET(4), 0xf57c0faf, 7)
-    STEP(F, d, a, b, c, SET(5), 0x4787c62a, 12)
-    STEP(F, c, d, a, b, SET(6), 0xa8304613, 17)
-    STEP(F, b, c, d, a, SET(7), 0xfd469501, 22)
-    STEP(F, a, b, c, d, SET(8), 0x698098d8, 7)
-    STEP(F, d, a, b, c, SET(9), 0x8b44f7af, 12)
-    STEP(F, c, d, a, b, SET(10), 0xffff5bb1, 17)
-    STEP(F, b, c, d, a, SET(11), 0x895cd7be, 22)
-    STEP(F, a, b, c, d, SET(12), 0x6b901122, 7)
-    STEP(F, d, a, b, c, SET(13), 0xfd987193, 12)
-    STEP(F, c, d, a, b, SET(14), 0xa679438e, 17)
-    STEP(F, b, c, d, a, SET(15), 0x49b40821, 22)
+		STEP(F, a, b, c, d, SET(0), 0xd76aa478, 7)
+		STEP(F, d, a, b, c, SET(1), 0xe8c7b756, 12)
+		STEP(F, c, d, a, b, SET(2), 0x242070db, 17)
+		STEP(F, b, c, d, a, SET(3), 0xc1bdceee, 22)
+		STEP(F, a, b, c, d, SET(4), 0xf57c0faf, 7)
+		STEP(F, d, a, b, c, SET(5), 0x4787c62a, 12)
+		STEP(F, c, d, a, b, SET(6), 0xa8304613, 17)
+		STEP(F, b, c, d, a, SET(7), 0xfd469501, 22)
+		STEP(F, a, b, c, d, SET(8), 0x698098d8, 7)
+		STEP(F, d, a, b, c, SET(9), 0x8b44f7af, 12)
+		STEP(F, c, d, a, b, SET(10), 0xffff5bb1, 17)
+		STEP(F, b, c, d, a, SET(11), 0x895cd7be, 22)
+		STEP(F, a, b, c, d, SET(12), 0x6b901122, 7)
+		STEP(F, d, a, b, c, SET(13), 0xfd987193, 12)
+		STEP(F, c, d, a, b, SET(14), 0xa679438e, 17)
+		STEP(F, b, c, d, a, SET(15), 0x49b40821, 22)
 
 /* Round 2 */
-    STEP(G, a, b, c, d, GET(1), 0xf61e2562, 5)
-    STEP(G, d, a, b, c, GET(6), 0xc040b340, 9)
-    STEP(G, c, d, a, b, GET(11), 0x265e5a51, 14)
-    STEP(G, b, c, d, a, GET(0), 0xe9b6c7aa, 20)
-    STEP(G, a, b, c, d, GET(5), 0xd62f105d, 5)
-    STEP(G, d, a, b, c, GET(10), 0x02441453, 9)
-    STEP(G, c, d, a, b, GET(15), 0xd8a1e681, 14)
-    STEP(G, b, c, d, a, GET(4), 0xe7d3fbc8, 20)
-    STEP(G, a, b, c, d, GET(9), 0x21e1cde6, 5)
-    STEP(G, d, a, b, c, GET(14), 0xc33707d6, 9)
-    STEP(G, c, d, a, b, GET(3), 0xf4d50d87, 14)
-    STEP(G, b, c, d, a, GET(8), 0x455a14ed, 20)
-    STEP(G, a, b, c, d, GET(13), 0xa9e3e905, 5)
-    STEP(G, d, a, b, c, GET(2), 0xfcefa3f8, 9)
-    STEP(G, c, d, a, b, GET(7), 0x676f02d9, 14)
-    STEP(G, b, c, d, a, GET(12), 0x8d2a4c8a, 20)
+		STEP(G, a, b, c, d, GET(1), 0xf61e2562, 5)
+		STEP(G, d, a, b, c, GET(6), 0xc040b340, 9)
+		STEP(G, c, d, a, b, GET(11), 0x265e5a51, 14)
+		STEP(G, b, c, d, a, GET(0), 0xe9b6c7aa, 20)
+		STEP(G, a, b, c, d, GET(5), 0xd62f105d, 5)
+		STEP(G, d, a, b, c, GET(10), 0x02441453, 9)
+		STEP(G, c, d, a, b, GET(15), 0xd8a1e681, 14)
+		STEP(G, b, c, d, a, GET(4), 0xe7d3fbc8, 20)
+		STEP(G, a, b, c, d, GET(9), 0x21e1cde6, 5)
+		STEP(G, d, a, b, c, GET(14), 0xc33707d6, 9)
+		STEP(G, c, d, a, b, GET(3), 0xf4d50d87, 14)
+		STEP(G, b, c, d, a, GET(8), 0x455a14ed, 20)
+		STEP(G, a, b, c, d, GET(13), 0xa9e3e905, 5)
+		STEP(G, d, a, b, c, GET(2), 0xfcefa3f8, 9)
+		STEP(G, c, d, a, b, GET(7), 0x676f02d9, 14)
+		STEP(G, b, c, d, a, GET(12), 0x8d2a4c8a, 20)
 
 /* Round 3 */
-    STEP(H, a, b, c, d, GET(5), 0xfffa3942, 4)
-    STEP(H, d, a, b, c, GET(8), 0x8771f681, 11)
-    STEP(H, c, d, a, b, GET(11), 0x6d9d6122, 16)
-    STEP(H, b, c, d, a, GET(14), 0xfde5380c, 23)
-    STEP(H, a, b, c, d, GET(1), 0xa4beea44, 4)
-    STEP(H, d, a, b, c, GET(4), 0x4bdecfa9, 11)
-    STEP(H, c, d, a, b, GET(7), 0xf6bb4b60, 16)
-    STEP(H, b, c, d, a, GET(10), 0xbebfbc70, 23)
-    STEP(H, a, b, c, d, GET(13), 0x289b7ec6, 4)
-    STEP(H, d, a, b, c, GET(0), 0xeaa127fa, 11)
-    STEP(H, c, d, a, b, GET(3), 0xd4ef3085, 16)
-    STEP(H, b, c, d, a, GET(6), 0x04881d05, 23)
-    STEP(H, a, b, c, d, GET(9), 0xd9d4d039, 4)
-    STEP(H, d, a, b, c, GET(12), 0xe6db99e5, 11)
-    STEP(H, c, d, a, b, GET(15), 0x1fa27cf8, 16)
-    STEP(H, b, c, d, a, GET(2), 0xc4ac5665, 23)
+		STEP(H, a, b, c, d, GET(5), 0xfffa3942, 4)
+		STEP(H, d, a, b, c, GET(8), 0x8771f681, 11)
+		STEP(H, c, d, a, b, GET(11), 0x6d9d6122, 16)
+		STEP(H, b, c, d, a, GET(14), 0xfde5380c, 23)
+		STEP(H, a, b, c, d, GET(1), 0xa4beea44, 4)
+		STEP(H, d, a, b, c, GET(4), 0x4bdecfa9, 11)
+		STEP(H, c, d, a, b, GET(7), 0xf6bb4b60, 16)
+		STEP(H, b, c, d, a, GET(10), 0xbebfbc70, 23)
+		STEP(H, a, b, c, d, GET(13), 0x289b7ec6, 4)
+		STEP(H, d, a, b, c, GET(0), 0xeaa127fa, 11)
+		STEP(H, c, d, a, b, GET(3), 0xd4ef3085, 16)
+		STEP(H, b, c, d, a, GET(6), 0x04881d05, 23)
+		STEP(H, a, b, c, d, GET(9), 0xd9d4d039, 4)
+		STEP(H, d, a, b, c, GET(12), 0xe6db99e5, 11)
+		STEP(H, c, d, a, b, GET(15), 0x1fa27cf8, 16)
+		STEP(H, b, c, d, a, GET(2), 0xc4ac5665, 23)
 
 /* Round 4 */
-    STEP(I, a, b, c, d, GET(0), 0xf4292244, 6)
-    STEP(I, d, a, b, c, GET(7), 0x432aff97, 10)
-    STEP(I, c, d, a, b, GET(14), 0xab9423a7, 15)
-    STEP(I, b, c, d, a, GET(5), 0xfc93a039, 21)
-    STEP(I, a, b, c, d, GET(12), 0x655b59c3, 6)
-    STEP(I, d, a, b, c, GET(3), 0x8f0ccc92, 10)
-    STEP(I, c, d, a, b, GET(10), 0xffeff47d, 15)
-    STEP(I, b, c, d, a, GET(1), 0x85845dd1, 21)
-    STEP(I, a, b, c, d, GET(8), 0x6fa87e4f, 6)
-    STEP(I, d, a, b, c, GET(15), 0xfe2ce6e0, 10)
-    STEP(I, c, d, a, b, GET(6), 0xa3014314, 15)
-    STEP(I, b, c, d, a, GET(13), 0x4e0811a1, 21)
-    STEP(I, a, b, c, d, GET(4), 0xf7537e82, 6)
-    STEP(I, d, a, b, c, GET(11), 0xbd3af235, 10)
-    STEP(I, c, d, a, b, GET(2), 0x2ad7d2bb, 15)
-    STEP(I, b, c, d, a, GET(9), 0xeb86d391, 21)
+		STEP(I, a, b, c, d, GET(0), 0xf4292244, 6)
+		STEP(I, d, a, b, c, GET(7), 0x432aff97, 10)
+		STEP(I, c, d, a, b, GET(14), 0xab9423a7, 15)
+		STEP(I, b, c, d, a, GET(5), 0xfc93a039, 21)
+		STEP(I, a, b, c, d, GET(12), 0x655b59c3, 6)
+		STEP(I, d, a, b, c, GET(3), 0x8f0ccc92, 10)
+		STEP(I, c, d, a, b, GET(10), 0xffeff47d, 15)
+		STEP(I, b, c, d, a, GET(1), 0x85845dd1, 21)
+		STEP(I, a, b, c, d, GET(8), 0x6fa87e4f, 6)
+		STEP(I, d, a, b, c, GET(15), 0xfe2ce6e0, 10)
+		STEP(I, c, d, a, b, GET(6), 0xa3014314, 15)
+		STEP(I, b, c, d, a, GET(13), 0x4e0811a1, 21)
+		STEP(I, a, b, c, d, GET(4), 0xf7537e82, 6)
+		STEP(I, d, a, b, c, GET(11), 0xbd3af235, 10)
+		STEP(I, c, d, a, b, GET(2), 0x2ad7d2bb, 15)
+		STEP(I, b, c, d, a, GET(9), 0xeb86d391, 21)
 
-    a += saved_a;
-    b += saved_b;
-    c += saved_c;
-    d += saved_d;
+		a += saved_a;
+		b += saved_b;
+		c += saved_c;
+		d += saved_d;
 
-    ptr += 64;
-  } while (size -= 64);
+		ptr += 64;
+	} while (size -= 64);
 
-  ctx->a = a;
-  ctx->b = b;
-  ctx->c = c;
-  ctx->d = d;
+	ctx->a = a;
+	ctx->b = b;
+	ctx->c = c;
+	ctx->d = d;
 
-  return ptr;
+	return ptr;
 }
 
 void MD5_Init(MD5_CTX *ctx)
 {
-  ctx->a = 0x67452301;
-  ctx->b = 0xefcdab89;
-  ctx->c = 0x98badcfe;
-  ctx->d = 0x10325476;
+	ctx->a = 0x67452301;
+	ctx->b = 0xefcdab89;
+	ctx->c = 0x98badcfe;
+	ctx->d = 0x10325476;
 
-  ctx->lo = 0;
-  ctx->hi = 0;
+	ctx->lo = 0;
+	ctx->hi = 0;
 }
 
 void MD5_Update(MD5_CTX *ctx, void *data, unsigned long size)
 {
-  MD5_u32plus saved_lo;
-  unsigned long used, free;
+	MD5_u32plus saved_lo;
+	unsigned long used, free;
 
-  saved_lo = ctx->lo;
-  if ((ctx->lo = (saved_lo + size) & 0x1fffffff) < saved_lo)
-    ctx->hi++;
-  ctx->hi += size >> 29;
+	saved_lo = ctx->lo;
+	if ((ctx->lo = (saved_lo + size) & 0x1fffffff) < saved_lo)
+		ctx->hi++;
+	ctx->hi += size >> 29;
 
-  used = saved_lo & 0x3f;
+	used = saved_lo & 0x3f;
 
-  if (used) {
-    free = 64 - used;
+	if (used) {
+		free = 64 - used;
 
-    if (size < free) {
-      memcpy(&ctx->buffer[used], data, size);
-      return;
-    }
+		if (size < free) {
+			memcpy(&ctx->buffer[used], data, size);
+			return;
+		}
 
-    memcpy(&ctx->buffer[used], data, free);
-    data = (unsigned char *)data + free;
-    size -= free;
-    body(ctx, ctx->buffer, 64);
-  }
+		memcpy(&ctx->buffer[used], data, free);
+		data = (unsigned char *)data + free;
+		size -= free;
+		body(ctx, ctx->buffer, 64);
+	}
 
-  if (size >= 64) {
-    data = body(ctx, data, size & ~(unsigned long)0x3f);
-    size &= 0x3f;
-  }
+	if (size >= 64) {
+		data = body(ctx, data, size & ~(unsigned long)0x3f);
+		size &= 0x3f;
+	}
 
-  memcpy(ctx->buffer, data, size);
+	memcpy(ctx->buffer, data, size);
 }
 
 void MD5_Final(unsigned char *result, MD5_CTX *ctx)
 {
-  unsigned long used, free;
+	unsigned long used, free;
 
-  used = ctx->lo & 0x3f;
+	used = ctx->lo & 0x3f;
 
-  ctx->buffer[used++] = 0x80;
+	ctx->buffer[used++] = 0x80;
 
-  free = 64 - used;
+	free = 64 - used;
 
-  if (free < 8) {
-    memset(&ctx->buffer[used], 0, free);
-    body(ctx, ctx->buffer, 64);
-    used = 0;
-    free = 64;
-  }
+	if (free < 8) {
+		memset(&ctx->buffer[used], 0, free);
+		body(ctx, ctx->buffer, 64);
+		used = 0;
+		free = 64;
+	}
 
-  memset(&ctx->buffer[used], 0, free - 8);
+	memset(&ctx->buffer[used], 0, free - 8);
 
-  ctx->lo <<= 3;
-  ctx->buffer[56] = ctx->lo;
-  ctx->buffer[57] = ctx->lo >> 8;
-  ctx->buffer[58] = ctx->lo >> 16;
-  ctx->buffer[59] = ctx->lo >> 24;
-  ctx->buffer[60] = ctx->hi;
-  ctx->buffer[61] = ctx->hi >> 8;
-  ctx->buffer[62] = ctx->hi >> 16;
-  ctx->buffer[63] = ctx->hi >> 24;
+	ctx->lo <<= 3;
+	ctx->buffer[56] = ctx->lo;
+	ctx->buffer[57] = ctx->lo >> 8;
+	ctx->buffer[58] = ctx->lo >> 16;
+	ctx->buffer[59] = ctx->lo >> 24;
+	ctx->buffer[60] = ctx->hi;
+	ctx->buffer[61] = ctx->hi >> 8;
+	ctx->buffer[62] = ctx->hi >> 16;
+	ctx->buffer[63] = ctx->hi >> 24;
 
-  body(ctx, ctx->buffer, 64);
+	body(ctx, ctx->buffer, 64);
 
-  result[0] = ctx->a;
-  result[1] = ctx->a >> 8;
-  result[2] = ctx->a >> 16;
-  result[3] = ctx->a >> 24;
-  result[4] = ctx->b;
-  result[5] = ctx->b >> 8;
-  result[6] = ctx->b >> 16;
-  result[7] = ctx->b >> 24;
-  result[8] = ctx->c;
-  result[9] = ctx->c >> 8;
-  result[10] = ctx->c >> 16;
-  result[11] = ctx->c >> 24;
-  result[12] = ctx->d;
-  result[13] = ctx->d >> 8;
-  result[14] = ctx->d >> 16;
-  result[15] = ctx->d >> 24;
+	result[0] = ctx->a;
+	result[1] = ctx->a >> 8;
+	result[2] = ctx->a >> 16;
+	result[3] = ctx->a >> 24;
+	result[4] = ctx->b;
+	result[5] = ctx->b >> 8;
+	result[6] = ctx->b >> 16;
+	result[7] = ctx->b >> 24;
+	result[8] = ctx->c;
+	result[9] = ctx->c >> 8;
+	result[10] = ctx->c >> 16;
+	result[11] = ctx->c >> 24;
+	result[12] = ctx->d;
+	result[13] = ctx->d >> 8;
+	result[14] = ctx->d >> 16;
+	result[15] = ctx->d >> 24;
 
-  memset(ctx, 0, sizeof(*ctx));
+	memset(ctx, 0, sizeof(*ctx));
 }
 
 #endif

--- a/plugins/obs-outputs/librtmp/md5.h
+++ b/plugins/obs-outputs/librtmp/md5.h
@@ -24,10 +24,9 @@
  */
 
 #ifdef HAVE_OPENSSL
-# include <openssl/md5.h>
-
+#include <openssl/md5.h>
 #elif !defined(_MD5_H)
-# define _MD5_H
+#define _MD5_H
 
 /* Any 32-bit or wider unsigned integer data type will do */
 typedef unsigned int MD5_u32plus;

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -32,13 +32,32 @@
 #include "rtmp_sys.h"
 #include "log.h"
 
+#include <util/platform.h>
+
+#if !defined(MSG_NOSIGNAL)
+#define MSG_NOSIGNAL 0
+#endif
+
 #ifdef CRYPTO
 
 #ifdef __APPLE__
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#ifdef USE_POLARSSL
+#if defined(USE_MBEDTLS)
+#if defined(_WIN32)
+#include <windows.h>
+#include <wincrypt.h>
+#elif defined(__APPLE__)
+#include <Security/Security.h>
+#endif
+
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/md5.h>
+#include <mbedtls/base64.h>
+#define MD5_DIGEST_LENGTH 16
+
+#elif defined(USE_POLARSSL)
 #include <polarssl/havege.h>
 #include <polarssl/md5.h>
 #include <polarssl/base64.h>
@@ -55,7 +74,6 @@ static const char *my_dhm_P =
     "E8A700D60B7F1200FA8E77B0A979DABF";
 
 static const char *my_dhm_G = "4";
-
 #elif defined(USE_GNUTLS)
 #include <gnutls/gnutls.h>
 #define MD5_DIGEST_LENGTH 16
@@ -68,7 +86,8 @@ static const char *my_dhm_G = "4";
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #endif
-TLS_CTX RTMP_TLS_ctx;
+
+TLS_CTX RTMP_TLS_ctx = NULL;
 #endif
 
 #define RTMP_SIG_SIZE 1536
@@ -224,9 +243,15 @@ RTMPPacket_Reset(RTMPPacket *p)
 }
 
 int
-RTMPPacket_Alloc(RTMPPacket *p, int nSize)
+RTMPPacket_Alloc(RTMPPacket *p, uint32_t nSize)
 {
-    char *ptr = calloc(1, nSize + RTMP_MAX_HEADER_SIZE);
+    char *ptr;
+#if ARCH_BITS == 32
+    if (nSize > SIZE_MAX - RTMP_MAX_HEADER_SIZE)
+        return FALSE;
+#endif
+
+    ptr = calloc(1, nSize + RTMP_MAX_HEADER_SIZE);
     if (!ptr)
         return FALSE;
     p->m_body = ptr + RTMP_MAX_HEADER_SIZE;
@@ -260,10 +285,100 @@ RTMP_LibVersion()
 }
 
 void
+RTMP_TLS_LoadCerts() {
+#ifdef USE_MBEDTLS
+    mbedtls_x509_crt *chain = RTMP_TLS_ctx->cacert = calloc(1, sizeof(struct mbedtls_x509_crt));
+    mbedtls_x509_crt_init(chain);
+
+#if defined(_WIN32)
+    HCERTSTORE hCertStore;
+    PCCERT_CONTEXT pCertContext = NULL;
+
+    if (!(hCertStore = CertOpenSystemStore((HCRYPTPROV)NULL, L"ROOT"))) {
+        goto error;
+    }
+
+    while (pCertContext = CertEnumCertificatesInStore(hCertStore, pCertContext)) {
+        mbedtls_x509_crt_parse_der(chain,
+                                   (unsigned char *)pCertContext->pbCertEncoded,
+                                   pCertContext->cbCertEncoded);
+    }
+
+    CertFreeCertificateContext(pCertContext);
+    CertCloseStore(hCertStore, 0);
+#elif defined(__APPLE__)
+    SecKeychainRef keychain_ref;
+    CFMutableDictionaryRef search_settings_ref;
+    CFArrayRef result_ref;
+
+    if (SecKeychainOpen("/System/Library/Keychains/SystemRootCertificates.keychain",
+                        &keychain_ref)
+        != errSecSuccess) {
+      goto error;
+    }
+
+    search_settings_ref = CFDictionaryCreateMutable(NULL, 0, NULL, NULL);
+    CFDictionarySetValue(search_settings_ref, kSecClass, kSecClassCertificate);
+    CFDictionarySetValue(search_settings_ref, kSecMatchLimit, kSecMatchLimitAll);
+    CFDictionarySetValue(search_settings_ref, kSecReturnRef, kCFBooleanTrue);
+    CFDictionarySetValue(search_settings_ref, kSecMatchSearchList,
+                         CFArrayCreate(NULL, (const void **)&keychain_ref, 1, NULL));
+
+    if (SecItemCopyMatching(search_settings_ref, (CFTypeRef *)&result_ref)
+        != errSecSuccess) {
+      goto error;
+    }
+
+    for (CFIndex i = 0; i < CFArrayGetCount(result_ref); i++) {
+      SecCertificateRef item_ref = (SecCertificateRef)
+                                   CFArrayGetValueAtIndex(result_ref, i);
+      CFDataRef data_ref;
+
+      if ((data_ref = SecCertificateCopyData(item_ref))) {
+        mbedtls_x509_crt_parse_der(chain,
+                                   (unsigned char *)CFDataGetBytePtr(data_ref),
+                                   CFDataGetLength(data_ref));
+        CFRelease(data_ref);
+      }
+    }
+
+    CFRelease(keychain_ref);
+#elif defined(__linux__)
+    if (mbedtls_x509_crt_parse_path(chain, "/etc/ssl/certs/") != 0) {
+        goto error;
+    }
+#endif
+
+    mbedtls_ssl_conf_ca_chain(&RTMP_TLS_ctx->conf, chain, NULL);
+    return;
+
+error:
+    mbedtls_x509_crt_free(chain);
+    free(chain);
+    RTMP_TLS_ctx->cacert = NULL;
+#endif /* USE_MBEDTLS */
+}
+
+void
 RTMP_TLS_Init()
 {
 #ifdef CRYPTO
-#ifdef USE_POLARSSL
+#if defined(USE_MBEDTLS)
+    const char * pers = "RTMP_TLS";
+    RTMP_TLS_ctx = calloc(1,sizeof(struct tls_ctx));
+
+    mbedtls_ssl_config_init(&RTMP_TLS_ctx->conf);
+    mbedtls_ctr_drbg_init(&RTMP_TLS_ctx->ctr_drbg);
+    mbedtls_entropy_init(&RTMP_TLS_ctx->entropy);
+
+    mbedtls_ctr_drbg_seed(&RTMP_TLS_ctx->ctr_drbg,
+                          mbedtls_entropy_func,
+                          &RTMP_TLS_ctx->entropy,
+                          (const unsigned char *)pers,
+                          strlen(pers));
+
+    RTMP_TLS_LoadCerts();
+#elif defined(USE_POLARSSL)
     /* Do this regardless of NO_SSL, we use havege for rtmpe too */
     RTMP_TLS_ctx = calloc(1,sizeof(struct tls_ctx));
     havege_init(&RTMP_TLS_ctx->hs);
@@ -287,6 +402,26 @@ RTMP_TLS_Init()
     SSL_CTX_set_options(RTMP_TLS_ctx, SSL_OP_ALL);
     SSL_CTX_set_default_verify_paths(RTMP_TLS_ctx);
 #endif
+#else
+#endif
+}
+
+void
+RTMP_TLS_Free() {
+#ifdef USE_MBEDTLS
+    mbedtls_ssl_config_free(&RTMP_TLS_ctx->conf);
+    mbedtls_ctr_drbg_free(&RTMP_TLS_ctx->ctr_drbg);
+    mbedtls_entropy_free(&RTMP_TLS_ctx->entropy);
+
+    if (RTMP_TLS_ctx->cacert) {
+        mbedtls_x509_crt_free(RTMP_TLS_ctx->cacert);
+        free(RTMP_TLS_ctx->cacert);
+        RTMP_TLS_ctx->cacert = NULL;
+    }
+
+    // NO mbedtls_net_free() BECAUSE WE SET IT UP BY HAND!
+    free(RTMP_TLS_ctx);
+    RTMP_TLS_ctx = NULL;
 #endif
 }
 
@@ -297,7 +432,27 @@ RTMP_TLS_AllocServerContext(const char* cert, const char* key)
 #ifdef CRYPTO
     if (!RTMP_TLS_ctx)
         RTMP_TLS_Init();
-#ifdef USE_POLARSSL
+#if defined(USE_MBEDTLS)
+    tls_server_ctx *tc = ctx = calloc(1, sizeof(struct tls_server_ctx));
+    tc->conf = &RTMP_TLS_ctx->conf;
+    tc->ctr_drbg = &RTMP_TLS_ctx->ctr_drbg;
+
+    mbedtls_x509_crt_init(&tc->cert);
+    if (mbedtls_x509_crt_parse_file(&tc->cert, cert))
+    {
+        free(tc);
+        return NULL;
+    }
+
+    mbedtls_pk_init(&tc->key);
+    if (mbedtls_pk_parse_keyfile(&tc->key, key, NULL))
+    {
+        mbedtls_x509_crt_free(&tc->cert);
+        mbedtls_pk_free(&tc->key);
+        free(tc);
+        return NULL;
+    }
+#elif defined(USE_POLARSSL)
     tls_server_ctx *tc = ctx = calloc(1, sizeof(struct tls_server_ctx));
     tc->dhm_P = my_dhm_P;
     tc->dhm_G = my_dhm_G;
@@ -344,7 +499,11 @@ void
 RTMP_TLS_FreeServerContext(void *ctx)
 {
 #ifdef CRYPTO
-#ifdef USE_POLARSSL
+#if defined(USE_MBEDTLS)
+    mbedtls_x509_crt_free(&((tls_server_ctx*)ctx)->cert);
+    mbedtls_pk_free(&((tls_server_ctx*)ctx)->key);
+    free(ctx);
+#elif defined(USE_POLARSSL)
     x509_free(&((tls_server_ctx*)ctx)->cert);
     rsa_free(&((tls_server_ctx*)ctx)->key);
     free(ctx);
@@ -368,6 +527,10 @@ RTMP_Alloc()
 void
 RTMP_Free(RTMP *r)
 {
+#if defined(CRYPTO) && defined(USE_MBEDTLS)
+  if (RTMP_TLS_ctx)
+    RTMP_TLS_Free();
+#endif
     free(r);
 }
 
@@ -650,7 +813,7 @@ int RTMP_AddStream(RTMP *r, const char *playpath)
 }
 
 static int
-add_addr_info(struct sockaddr_storage *service, socklen_t *addrlen, AVal *host, int port, socklen_t addrlen_hint)
+add_addr_info(struct sockaddr_storage *service, socklen_t *addrlen, AVal *host, int port, socklen_t addrlen_hint, int *socket_error)
 {
     char *hostname;
     int ret = TRUE;
@@ -691,6 +854,7 @@ add_addr_info(struct sockaddr_storage *service, socklen_t *addrlen, AVal *host, 
 #define gai_strerrorA gai_strerror
 #endif
         RTMP_Log(RTMP_LOGERROR, "Could not resolve %s: %s (%d)", hostname, gai_strerrorA(GetSockError()), GetSockError());
+        *socket_error = GetSockError();
         ret = FALSE;
         goto finish;
     }
@@ -706,23 +870,32 @@ add_addr_info(struct sockaddr_storage *service, socklen_t *addrlen, AVal *host, 
         }
     }
 
-	if (!*addrlen)
-	{
-		for (ptr = result; ptr != NULL; ptr = ptr->ai_next)
-		{
+    if (!*addrlen)
+    {
+        for (ptr = result; ptr != NULL; ptr = ptr->ai_next)
+        {
             if (ptr->ai_family == AF_INET6 && (!addrlen_hint || ptr->ai_addrlen == addrlen_hint))
-			{
-				memcpy(service, ptr->ai_addr, ptr->ai_addrlen);
-				*addrlen = (socklen_t)ptr->ai_addrlen;
-				break;
-			}
-		}
-	}
+            {
+                memcpy(service, ptr->ai_addr, ptr->ai_addrlen);
+                *addrlen = (socklen_t)ptr->ai_addrlen;
+                break;
+            }
+        }
+    }
 
     freeaddrinfo(result);
 
     if (service->ss_family == AF_UNSPEC || *addrlen == 0)
     {
+        // since we're handling multiple addresses internally, fake the correct error response
+#ifdef _WIN32
+        *socket_error = WSANO_DATA;
+#elif __FreeBSD__
+        *socket_error = ENOATTR;
+#else
+        *socket_error = ENODATA;
+#endif
+
         RTMP_Log(RTMP_LOGERROR, "Could not resolve server '%s': no valid address found", hostname);
         ret = FALSE;
         goto finish;
@@ -761,6 +934,11 @@ RTMP_Connect0(RTMP *r, struct sockaddr * service, socklen_t addrlen)
 
     if (r->m_sb.sb_socket != INVALID_SOCKET)
     {
+#ifndef _WIN32
+#ifdef SO_NOSIGPIPE
+        setsockopt(r->m_sb.sb_socket, SOL_SOCKET, SO_NOSIGPIPE, &(int){ 1 }, sizeof(int));
+#endif
+#endif
         if(r->m_bindIP.addrLen)
         {
             if (bind(r->m_sb.sb_socket, (const struct sockaddr *)&r->m_bindIP.addr, r->m_bindIP.addrLen) < 0)
@@ -768,10 +946,13 @@ RTMP_Connect0(RTMP *r, struct sockaddr * service, socklen_t addrlen)
                 int err = GetSockError();
                 RTMP_Log(RTMP_LOGERROR, "%s, failed to bind socket: %s (%d)",
                          __FUNCTION__, socketerror(err), err);
+                r->last_error_code = err;
                 RTMP_Close(r);
                 return FALSE;
             }
         }
+
+        uint64_t connect_start = os_gettime_ns();
 
         if (connect(r->m_sb.sb_socket, service, addrlen) < 0)
         {
@@ -785,9 +966,12 @@ RTMP_Connect0(RTMP *r, struct sockaddr * service, socklen_t addrlen)
             else
                 RTMP_Log(RTMP_LOGERROR, "%s, failed to connect socket: %s (%d)",
                      __FUNCTION__, socketerror(err), err);
+            r->last_error_code = err;
             RTMP_Close(r);
             return FALSE;
         }
+
+        r->connect_time_ms = (int)((os_gettime_ns() - connect_start) / 1000000);
 
         if (r->Link.socksport)
         {
@@ -828,9 +1012,20 @@ int
 RTMP_TLS_Accept(RTMP *r, void *ctx)
 {
 #if defined(CRYPTO) && !defined(NO_SSL)
-    TLS_server(ctx, r->m_sb.sb_ssl);
+    tls_server_ctx *srv_ctx = ctx;
+    TLS_server(srv_ctx, r->m_sb.sb_ssl);
+
+#if defined(USE_MBEDTLS)
+    mbedtls_net_context *client_fd = &RTMP_TLS_ctx->net;
+    mbedtls_net_init(client_fd);
+    client_fd->fd = r->m_sb.sb_socket;
+    TLS_setfd(r->m_sb.sb_ssl, client_fd);
+#else
     TLS_setfd(r->m_sb.sb_ssl, r->m_sb.sb_socket);
-    if (TLS_accept(r->m_sb.sb_ssl) < 0)
+#endif
+
+    int connect_return = TLS_connect(r->m_sb.sb_ssl);
+    if (connect_return < 0)
     {
         RTMP_Log(RTMP_LOGERROR, "%s, TLS_Connect failed", __FUNCTION__);
         return FALSE;
@@ -850,10 +1045,59 @@ RTMP_Connect1(RTMP *r, RTMPPacket *cp)
     {
 #if defined(CRYPTO) && !defined(NO_SSL)
         TLS_client(RTMP_TLS_ctx, r->m_sb.sb_ssl);
+
+#if defined(USE_MBEDTLS)
+        mbedtls_net_context *server_fd = &RTMP_TLS_ctx->net;
+        server_fd->fd = r->m_sb.sb_socket;
+        TLS_setfd(r->m_sb.sb_ssl, server_fd);
+
+        // make sure we verify the certificate hostname
+        char hostname[MBEDTLS_SSL_MAX_HOST_NAME_LEN + 1];
+
+        if (r->Link.hostname.av_len >= MBEDTLS_SSL_MAX_HOST_NAME_LEN)
+            return FALSE;
+
+        memcpy(hostname, r->Link.hostname.av_val, r->Link.hostname.av_len);
+        hostname[r->Link.hostname.av_len] = 0;
+
+        if (mbedtls_ssl_set_hostname(r->m_sb.sb_ssl, hostname))
+            return FALSE;
+#else
         TLS_setfd(r->m_sb.sb_ssl, r->m_sb.sb_socket);
-        if (TLS_connect(r->m_sb.sb_ssl) < 0)
+#endif
+
+        int connect_return = TLS_connect(r->m_sb.sb_ssl);
+        if (connect_return < 0)
         {
-            RTMP_Log(RTMP_LOGERROR, "%s, TLS_Connect failed", __FUNCTION__);
+#if defined(USE_MBEDTLS)
+            if (connect_return == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED)
+            {
+                r->last_error_code = connect_return;
+
+                // show a more detailed error in the log if possible
+                int verify_result = mbedtls_ssl_get_verify_result(r->m_sb.sb_ssl);
+                if (verify_result)
+                {
+                    char err[256], *e;
+                    if (mbedtls_x509_crt_verify_info(err, sizeof(err), "", verify_result) > 0)
+                    {
+                        e = strchr(err, '\n');
+                        if (e)
+                            *e = '\0';
+                    }
+                    else
+                    {
+                        strcpy(err, "unknown error");
+                    }
+                    RTMP_Log(RTMP_LOGERROR, "%s, Cert verify failed: %d (%s)", __FUNCTION__, verify_result, err);
+                    RTMP_Close(r);
+                    return FALSE;
+                }
+            }
+#endif
+            // output the error in a format that matches mbedTLS
+            connect_return = abs(connect_return);
+            RTMP_Log(RTMP_LOGERROR, "%s, TLS_Connect failed: -0x%x", __FUNCTION__, connect_return);
             RTMP_Close(r);
             return FALSE;
         }
@@ -861,7 +1105,6 @@ RTMP_Connect1(RTMP *r, RTMPPacket *cp)
         RTMP_Log(RTMP_LOGERROR, "%s, no SSL/TLS support", __FUNCTION__);
         RTMP_Close(r);
         return FALSE;
-
 #endif
     }
     if (r->Link.protocol & RTMP_FEATURE_HTTP)
@@ -906,6 +1149,8 @@ RTMP_Connect(RTMP *r, RTMPPacket *cp)
     struct sockaddr_storage service;
     socklen_t addrlen = 0;
     socklen_t addrlen_hint = 0;
+    int socket_error = 0;
+
     if (!r->Link.hostname.av_len)
         return FALSE;
 
@@ -914,6 +1159,7 @@ RTMP_Connect(RTMP *r, RTMPPacket *cp)
     h = gethostbyname("localhost");
     if (!h && GetLastError() == WSAHOST_NOT_FOUND)
     {
+        r->last_error_code = WSAHOST_NOT_FOUND;
         RTMP_Log(RTMP_LOGERROR, "RTMP_Connect: Connection test failed. This error is likely caused by Comodo Internet Security running OBS in sandbox mode. Please add OBS to the Comodo automatic sandbox exclusion list, restart OBS and try again (11001).");
         return FALSE;
     }
@@ -927,14 +1173,20 @@ RTMP_Connect(RTMP *r, RTMPPacket *cp)
     if (r->Link.socksport)
     {
         /* Connect via SOCKS */
-        if (!add_addr_info(&service, &addrlen, &r->Link.sockshost, r->Link.socksport, addrlen_hint))
+        if (!add_addr_info(&service, &addrlen, &r->Link.sockshost, r->Link.socksport, addrlen_hint, &socket_error))
+        {
+            r->last_error_code = socket_error;
             return FALSE;
+        }
     }
     else
     {
         /* Connect directly */
-        if (!add_addr_info(&service, &addrlen, &r->Link.hostname, r->Link.port, addrlen_hint))
+        if (!add_addr_info(&service, &addrlen, &r->Link.hostname, r->Link.port, addrlen_hint, &socket_error))
+        {
+            r->last_error_code = socket_error;
             return FALSE;
+        }
     }
 
     if (!RTMP_Connect0(r, (struct sockaddr *)&service, addrlen))
@@ -951,9 +1203,10 @@ SocksNegotiate(RTMP *r)
     unsigned long addr;
     struct sockaddr_storage service;
     socklen_t addrlen = 0;
+    int socket_error = 0;
     memset(&service, 0, sizeof(service));
 
-    add_addr_info(&service, &addrlen, &r->Link.hostname, r->Link.port, 0);
+    add_addr_info(&service, &addrlen, &r->Link.hostname, r->Link.port, 0, &socket_error);
 
     // not doing IPv6 socks
     if (service.ss_family == AF_INET6)
@@ -1080,7 +1333,7 @@ RTMP_GetNextMediaPacket(RTMP *r, RTMPPacket *packet)
     while (!bHasMediaPacket && RTMP_IsConnected(r)
             && RTMP_ReadPacket(r, packet))
     {
-        if (!RTMPPacket_IsReady(packet))
+        if (!RTMPPacket_IsReady(packet) || !packet->m_nBodySize)
         {
             continue;
         }
@@ -1435,6 +1688,8 @@ WriteN(RTMP *r, const char *buffer, int n)
 
             if (sockerr == EINTR && !RTMP_ctrlC)
                 continue;
+
+            r->last_error_code = sockerr;
 
             RTMP_Close(r);
             n = 1;
@@ -2368,7 +2623,19 @@ b64enc(const unsigned char *input, int length, char *output, int maxsize)
 {
     (void)maxsize;
 
-#ifdef USE_POLARSSL
+#if defined(USE_MBEDTLS)
+    size_t osize;
+    if(mbedtls_base64_encode((unsigned char *) output, maxsize, &osize, input, length) == 0)
+    {
+        output[osize] = '\0';
+        return 1;
+    }
+    else
+    {
+        RTMP_Log(RTMP_LOGDEBUG, "%s, error", __FUNCTION__);
+        return 0;
+    }
+#elif defined(USE_POLARSSL)
     size_t buf_size = maxsize;
     if(base64_encode((unsigned char *) output, &buf_size, input, length) == 0)
     {
@@ -2427,7 +2694,13 @@ b64enc(const unsigned char *input, int length, char *output, int maxsize)
     return 1;
 }
 
-#ifdef USE_POLARSSL
+#if defined(USE_MBEDTLS)
+typedef	mbedtls_md5_context MD5_CTX;
+#define MD5_Init(ctx)	mbedtls_md5_init(ctx); mbedtls_md5_starts(ctx)
+#define MD5_Update(ctx,data,len)	mbedtls_md5_update(ctx,(unsigned char *)data,len)
+#define MD5_Final(dig,ctx)	mbedtls_md5_finish(ctx,dig); mbedtls_md5_free(ctx)
+
+#elif defined(USE_POLARSSL)
 #define MD5_CTX	md5_context
 #define MD5_Init(ctx)	md5_starts(ctx)
 #define MD5_Update(ctx,data,len)	md5_update(ctx,(unsigned char *)data,len)
@@ -3683,7 +3956,6 @@ RTMP_ReadPacket(RTMP *r, RTMPPacket *packet)
         {
             packet->m_nBodySize = AMF_DecodeInt24(header + 3);
             packet->m_nBytesRead = 0;
-            RTMPPacket_Free(packet);
 
             if (nSize > 6)
             {
@@ -4326,7 +4598,7 @@ RTMPSockBuf_Fill(RTMPSockBuf *sb)
         else
 #endif
         {
-            nBytes = recv(sb->sb_socket, sb->sb_start + sb->sb_size, nBytes, 0);
+            nBytes = recv(sb->sb_socket, sb->sb_start + sb->sb_size, nBytes, MSG_NOSIGNAL);
         }
         if (nBytes > 0)
         {
@@ -4379,7 +4651,7 @@ RTMPSockBuf_Send(RTMPSockBuf *sb, const char *buf, int len)
     else
 #endif
     {
-        rc = send(sb->sb_socket, buf, len, 0);
+        rc = send(sb->sb_socket, buf, len, MSG_NOSIGNAL);
     }
     return rc;
 }

--- a/plugins/obs-outputs/librtmp/rtmp.h
+++ b/plugins/obs-outputs/librtmp/rtmp.h
@@ -150,7 +150,7 @@ extern "C"
 
     void RTMPPacket_Reset(RTMPPacket *p);
     void RTMPPacket_Dump(RTMPPacket *p);
-    int RTMPPacket_Alloc(RTMPPacket *p, int nSize);
+    int RTMPPacket_Alloc(RTMPPacket *p, uint32_t nSize);
     void RTMPPacket_Free(RTMPPacket *p);
 
 #define RTMPPacket_IsReady(a)	((a)->m_nBytesRead == (a)->m_nBodySize)
@@ -381,6 +381,7 @@ extern "C"
     void RTMP_Init(RTMP *r);
     void RTMP_Close(RTMP *r);
     RTMP *RTMP_Alloc(void);
+    void RTMP_TLS_Free();
     void RTMP_Free(RTMP *r);
     void RTMP_EnableWrite(RTMP *r);
 

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -1,7 +1,7 @@
 #include <obs-module.h>
 
 struct rtmp_custom {
-	char *server, *room;
+	char *server, *key;
 	bool use_auth;
 	char *username, *password;
 };
@@ -17,10 +17,10 @@ static void rtmp_custom_update(void *data, obs_data_t *settings)
 	struct rtmp_custom *service = data;
 
 	bfree(service->server);
-	bfree(service->room);
+	bfree(service->key);
 
 	service->server = bstrdup(obs_data_get_string(settings, "server"));
-	service->room    = bstrdup(obs_data_get_string(settings, "room"));
+	service->key = bstrdup(obs_data_get_string(settings, "key"));
 	service->use_auth = obs_data_get_bool(settings, "use_auth");
 	service->username = bstrdup(obs_data_get_string(settings, "username"));
 	service->password = bstrdup(obs_data_get_string(settings, "password"));
@@ -31,7 +31,7 @@ static void rtmp_custom_destroy(void *data)
 	struct rtmp_custom *service = data;
 
 	bfree(service->server);
-	bfree(service->room);
+	bfree(service->key);
 	bfree(service->username);
 	bfree(service->password);
 	bfree(service);
@@ -47,7 +47,7 @@ static void *rtmp_custom_create(obs_data_t *settings, obs_service_t *service)
 }
 
 static bool use_auth_modified(obs_properties_t *ppts, obs_property_t *p,
-	obs_data_t *settings)
+			      obs_data_t *settings)
 {
 	bool use_auth = obs_data_get_bool(settings, "use_auth");
 	p = obs_properties_get(ppts, "username");
@@ -66,14 +66,15 @@ static obs_properties_t *rtmp_custom_properties(void *unused)
 
 	obs_properties_add_text(ppts, "server", "URL", OBS_TEXT_DEFAULT);
 
-	obs_properties_add_text(ppts, "room", obs_module_text("Room"),
-			OBS_TEXT_PASSWORD);
+	obs_properties_add_text(ppts, "key", obs_module_text("StreamKey"),
+				OBS_TEXT_PASSWORD);
 
-	p = obs_properties_add_bool(ppts, "use_auth", obs_module_text("UseAuth"));
+	p = obs_properties_add_bool(ppts, "use_auth",
+				    obs_module_text("UseAuth"));
 	obs_properties_add_text(ppts, "username", obs_module_text("Username"),
-			OBS_TEXT_DEFAULT);
+				OBS_TEXT_DEFAULT);
 	obs_properties_add_text(ppts, "password", obs_module_text("Password"),
-			OBS_TEXT_PASSWORD);
+				OBS_TEXT_PASSWORD);
 	obs_property_set_modified_callback(p, use_auth_modified);
 	return ppts;
 }
@@ -84,10 +85,10 @@ static const char *rtmp_custom_url(void *data)
 	return service->server;
 }
 
-static const char *rtmp_custom_room(void *data)
+static const char *rtmp_custom_key(void *data)
 {
 	struct rtmp_custom *service = data;
-	return service->room;
+	return service->key;
 }
 
 static const char *rtmp_custom_username(void *data)
@@ -106,15 +107,23 @@ static const char *rtmp_custom_password(void *data)
 	return service->password;
 }
 
+static const char *rtmp_custom_room(void *data)
+{
+	UNUSED_PARAMETER(data);
+
+	return "1";
+}
+
 struct obs_service_info rtmp_custom_service = {
-	.id             = "rtmp_custom",
-	.get_name       = rtmp_custom_name,
-	.create         = rtmp_custom_create,
-	.destroy        = rtmp_custom_destroy,
-	.update         = rtmp_custom_update,
+	.id = "rtmp_custom",
+	.get_name = rtmp_custom_name,
+	.create = rtmp_custom_create,
+	.destroy = rtmp_custom_destroy,
+	.update = rtmp_custom_update,
 	.get_properties = rtmp_custom_properties,
-	.get_url        = rtmp_custom_url,
-	.get_room        = rtmp_custom_room,
-	.get_username   = rtmp_custom_username,
-	.get_password   = rtmp_custom_password
+	.get_url = rtmp_custom_url,
+	.get_key = rtmp_custom_key,
+	.get_username = rtmp_custom_username,
+	.get_password = rtmp_custom_password,
+	.get_room     = rtmp_custom_room
 };


### PR DESCRIPTION
Replacing `rtmpservices/rtmp-custom.c` from obs-studio trunk (23.2) fixes the Custom RTMP Server service (restores Stream Key field in Stream Settings).