### PR TITLE
[EBS] Add workaround for Catalina

### DIFF
--- a/vendor_skins/Evercast/cmake/osxbundle/obslaunch.sh
+++ b/vendor_skins/Evercast/cmake/osxbundle/obslaunch.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
-cd "$(dirname "$0")"
-cd ../Resources/bin
-exec ./ebs "$@"
+# use argument 1 as the version or get it from sw_vers
+os_ver=$(sw_vers -productVersion)
 
+if [[ "$os_ver" == 10.15.* ]]; then
+	echo "macOS Catalina"
+	osascript -e "tell app \"Terminal\" to do script \"cd /Applications/EBS.app/Contents/Resources/bin && ./ebs\""
+else
+	cd "$(dirname "$0")"
+  cd ../Resources/bin
+  exec ./ebs "$@"
+fi


### PR DESCRIPTION
## Description
This adds an easier way to open EBS in macOS Catalina by applying a workaround through the launch script, instead of requesting the user to open the Terminal app manually.