### PR TITLE
update 'output->video' object when video settings changed

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -507,6 +507,8 @@ void obs_output_update(obs_output_t *output, obs_data_t *settings)
 	if (!obs_output_valid(output, "obs_output_update"))
 		return;
 
+        output->video = obs_get_video();
+
 	obs_data_apply(output->context.settings, settings);
 
 	if (output->info.update)


### PR DESCRIPTION
When video settings changed, the old `video` object is destroyed [here](https://github.com/CoSMoSoftware/OBS-studio-webrtc/blob/master/libobs/obs.c#L1082) - leaving the `output` with an invalid `video` object.

The solution is to update `output->video` pointer to point to a valid object.