### PR TITLE
Correctly handle password/token in webrtc_custom service

### DIFF
--- a/plugins/rtmp-services/webrtc-custom.c
+++ b/plugins/rtmp-services/webrtc-custom.c
@@ -26,6 +26,7 @@ static void webrtc_custom_update(void *data, obs_data_t *settings)
 	bfree(service->output);
 
 	service->server = bstrdup(obs_data_get_string(settings, "server"));
+	service->password = bstrdup(obs_data_get_string(settings, "password"));
 	service->codec = bstrdup(obs_data_get_string(settings, "codec"));
 	service->simulcast = obs_data_get_bool(settings, "simulcast");
 	service->output = bstrdup("webrtc_custom_output");
@@ -133,8 +134,8 @@ static const char *webrtc_custom_url(void *data)
 
 static const char *webrtc_custom_key(void *data)
 {
-	UNUSED_PARAMETER(data);
-	return NULL;
+	struct webrtc_custom *service = data;
+	return service->password;
 }
 
 static const char *webrtc_custom_room(void *data)


### PR DESCRIPTION
Added code to make use of the password/token on the stream page for the WebRTC Custom Service.

Currently in WebRTC Custom Service, the password/token box is ignored, which is required for some services.

To support this, I changed the `webrtc_custom_key` function to return the value stored in the service struct, and update the value in the service struct during the `webrtc_custom_update`.

