### PR TITLE
Revert "Correctly handle password/token in webrtc_custom service"

### DIFF
--- a/plugins/rtmp-services/webrtc-custom.c
+++ b/plugins/rtmp-services/webrtc-custom.c
@@ -26,7 +26,6 @@ static void webrtc_custom_update(void *data, obs_data_t *settings)
 	bfree(service->output);
 
 	service->server = bstrdup(obs_data_get_string(settings, "server"));
-	service->password = bstrdup(obs_data_get_string(settings, "password"));
 	service->codec = bstrdup(obs_data_get_string(settings, "codec"));
 	service->simulcast = obs_data_get_bool(settings, "simulcast");
 	service->output = bstrdup("webrtc_custom_output");
@@ -134,8 +133,8 @@ static const char *webrtc_custom_url(void *data)
 
 static const char *webrtc_custom_key(void *data)
 {
-	struct webrtc_custom *service = data;
-	return service->password;
+	UNUSED_PARAMETER(data);
+	return NULL;
 }
 
 static const char *webrtc_custom_room(void *data)


### PR DESCRIPTION
Reverts CoSMoSoftware/OBS-studio-webrtc#304

This fork was created in part because many actors in the OBS ecosystem could not get  together and implement a standard webrtc stack. Caffeine.Tv among others had a custom implementation and was trying to get it maintained upstream. The goal here is to solve the problem once and for all by using a standard implementation that anybody can use.

Custom webrtc uses WHIP standard, which does not have a password/token feature. Maybe it should, and you can bring it to the discussion at IETF.

In the mean time, we do not accept, and certainly will not maintain, custom implementations.

If you or moxion want a custom implementation in the mean time, or support H264 with/without an MPEG-LA license (royalties are to be paid by the one compiling and distributing), or modify our code unilaterally, it's a free world and you are entitled to it, in your own fork.
