### PR TITLE
DIOS-292: fix color space switch crash

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -735,6 +735,8 @@ bool SimpleOutput::SetupStreaming(obs_service_t *service)
 	if (!Active())
 		SetupOutputs();
 
+	obs_output_set_media(streamOutput, obs_get_video(), obs_get_audio());
+
 	Auth *auth = main->GetAuth();
 	if (auth)
 		auth->OnStreamConfig();


### PR DESCRIPTION
Ticket reference: [DIOS-292](https://jira.dolby.net/jira/browse/DIOS-292) 

This patch fixes the crash happening whenever you switch pixel formats. The issue boils down to not updating the video object within the output when you setup the stream. 